### PR TITLE
Fix issue #7 about `path` variable

### DIFF
--- a/providers/port_options.rb
+++ b/providers/port_options.rb
@@ -110,7 +110,7 @@ end
 
 def port_path
   whereis = shell_out!("whereis -s #{@new_resource.name}", env: nil)
-  unless path == whereis.stdout[/^#{@new_resource.name}:\s+(.+)$/, 1]
+  unless path = whereis.stdout[/^#{@new_resource.name}:\s+(.+)$/, 1]
     fail Chef::Exceptions::Package, "Could not find port with the name #{@new_resource.name}"
   end
   path

--- a/providers/port_options.rb
+++ b/providers/port_options.rb
@@ -110,9 +110,8 @@ end
 
 def port_path
   whereis = shell_out!("whereis -s #{@new_resource.name}", env: nil)
-  unless path = whereis.stdout[/^#{@new_resource.name}:\s+(.+)$/, 1]
-    fail Chef::Exceptions::Package, "Could not find port with the name #{@new_resource.name}"
-  end
+  path = whereis.stdout[/^#{@new_resource.name}:\s+(.+)$/, 1]
+  fail Chef::Exceptions::Package, "Could not find port with the name #{@new_resource.name}" unless path
   path
 end
 


### PR DESCRIPTION
It is assignment, not comparison. It was so in a earlier version and it works.