### PR TITLE
Only match against major FreeBSD versions

### DIFF
--- a/recipes/portsnap.rb
+++ b/recipes/portsnap.rb
@@ -18,8 +18,9 @@
 #
 
 if node['platform'] == 'freebsd'
-  case node['platform_version'].split('.').first
-  when /10/, /11/
+  platform_major_version = node['platform_version'].split('.').first.to_i
+
+  if platform_major_version >= 10
     portsnap_bin = 'portsnap'
     portsnap_options = '--interactive'
   else

--- a/recipes/portsnap.rb
+++ b/recipes/portsnap.rb
@@ -18,8 +18,8 @@
 #
 
 if node['platform'] == 'freebsd'
-  case node['platform_version']
-  when /10/
+  case node['platform_version'].split('.').first
+  when /10/, /11/
     portsnap_bin = 'portsnap'
     portsnap_options = '--interactive'
   else


### PR DESCRIPTION
### Description

Using regex to match against the entire `platform_version` string can produce unexpected results if a host's minor or patch version includes the major version we're trying to match.

e.g. `9.3-RELEASE-p10` would be a positive match for `/10/`

I've also added support for FreeBSD 11 to the portsnap recipe.

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>